### PR TITLE
Jenkinsfile: remove upstream builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,3 @@
-servicePipeline(
-    upstreamProjects: ['dockers/master'],
-)
+servicePipeline()
 
 // vim: ft=groovy


### PR DESCRIPTION
This build doesn't depend on the OCF base docker images, so the dockers upstream isn't necessary.